### PR TITLE
Updated query_sets

### DIFF
--- a/cmd/xenia/scrquery/comments_by_asset.json
+++ b/cmd/xenia/scrquery/comments_by_asset.json
@@ -6,10 +6,10 @@
       {
          "name":"comments_by_asset",
          "type":"pipeline",
-         "collection":"nyt_coral_assets",
+         "collection":"comments",
          "return":true,
          "commands":[
-            { "$match": { "asset_id": "#number:asset_id" } },
+            { "$match": { "asset_id": "#objid:asset_id" } },
             { "$sort": { "createDate": -1 } }
          ]
       }

--- a/cmd/xenia/scrquery/comments_by_user.json
+++ b/cmd/xenia/scrquery/comments_by_user.json
@@ -6,10 +6,10 @@
       {
          "name":"comments_by_user",
          "type":"pipeline",
-         "collection":"nyt_coral_comments",
+         "collection":"comments",
          "return":true,
          "commands":[
-            { "$match": { "user_id": "#number:user_id" } },
+            { "$match": { "user_id": "#objid:user_id" } },
             { "$sort": { "createDate": -1 } }
          ]
       }

--- a/cmd/xenia/scrquery/comments_per_day.json
+++ b/cmd/xenia/scrquery/comments_per_day.json
@@ -6,7 +6,7 @@
       {
          "name":"comments_by_asset",
          "type":"pipeline",
-         "collection":"comment",
+         "collection":"comments",
          "return":true,
          "commands":[
             { "$match": { "date_created": {"$gt" : "#date:start_date"} } },

--- a/cmd/xenia/scrquery/top_commenters_by_count.json
+++ b/cmd/xenia/scrquery/top_commenters_by_count.json
@@ -6,7 +6,7 @@
       {
          "name":"top_commenters_by_count",
          "type":"pipeline",
-         "collection":"nyt_coral_comments",
+         "collection":"comments",
          "return":true,
          "commands":[
             { "$group": { "_id": { "user_id": "$user_id" }, "comments": { "$sum": 1 } } },

--- a/cmd/xenia/scrquery/top_commenters_by_recs.json
+++ b/cmd/xenia/scrquery/top_commenters_by_recs.json
@@ -6,7 +6,7 @@
       {
          "name":"top_commenters_by_likes",
          "type":"pipeline",
-         "collection":"nyt_coral_comments",
+         "collection":"comments",
          "return":true,
          "commands":[
             { "$group": { "_id": { "user_id": "$user_id" }, "recommendationCount": { "$sum": 1 } } },


### PR DESCRIPTION
## What does this PR do?

Updates the `.json` query sets for the Xenia application. There seems to be some naming differentiation between the collections created by `pillar` and the collections examined by the current query sets.

This PR makes the query sets more in-line with the expected collection names and types in MongoDB.
See here for the expected collection names in Pillar - [Pillar Object Types](https://github.com/coralproject/pillar/blob/bf9963941ad780c8f1206ef6e3622c480bb6db35/pkg/model/object.go#L35-L48)

