### PR TITLE
Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@
 # and a workspace (GOPATH) configured at /go.
 FROM golang:1.5.3
 ENV GO15VENDOREXPERIMENT="1"
+
 # Copy the local package files to the container's workspace.
 COPY . /go/src/github.com/coralproject/xenia
+
 # Build & Install
-RUN cd /go/src && go install github.com/coralproject/xenia/cmd/xeniad
+RUN cd /go/src && go install github.com/coralproject/xenia/cmd/xeniad && go install github.com/coralproject/xenia/cmd/xenia
+
 # Run the app
-ENTRYPOINT /go/bin/xeniad
+ENTRYPOINT ["/go/src/github.com/coralproject/xenia/entrypoint.sh"]
+
 # Document that the service listens on port 8080.
 EXPOSE 4000

--- a/cmd/xenia/cmdquery/upsert.go
+++ b/cmd/xenia/cmdquery/upsert.go
@@ -50,13 +50,11 @@ func runUpsert(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	pwd, err := os.Getwd()
+	file, err := filepath.Abs(upsert.path)
 	if err != nil {
 		cmd.Println("Upserting Set : ", err)
 		return
 	}
-
-	file := filepath.Join(pwd, upsert.path)
 
 	stat, err := os.Stat(file)
 	if err != nil {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,15 @@ DEFAULT_XENIA_COMMAND_PATH=/go/src/github.com/coralproject/xenia/cmd/xenia
 PATH=/go/bin:${PATH}
 
 # Create the database collections if environment variable XENIA_CREATE_DATABASE is present.
-# XENIA_DATABASE_JSON - the location of the scrdb json.
+# XENIA_DATABASE_SCHEMA_PATH - the location of the scrdb json.
 if [ ! -z ${XENIA_CREATE_DATABASE:-} ]; then
-    xenia db create -f ${XENIA_DATABASE_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
+    xenia db create -f ${XENIA_DATABASE_SCHEMA_PATH:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
 fi  
 
 # Update queries if the environment variable XENIA_UPDATE_QUERY is present.
-# XENIA_QUERY_JSON - the location of the scrquery directory.
+# XENIA_QUERY_UPSERT_PATH - the location of the scrquery directory or individual query file.
 if [ ! -z ${XENIA_UPDATE_QUERY:-} ]; then
-    xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery}
+    xenia query upsert -p ${XENIA_QUERY_UPSERT_PATH:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery}
 fi
 
 # Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Update queries if the environment variable XENIA_UPDATE_QUERY is present.
 # XENIA_QUERY_JSON - the location of the scrquery directory.
-if [ ! -z ${XENIA_UPDATE_QUERY:-}]; then
+if [ ! -z ${XENIA_UPDATE_QUERY:-} ]; then
     /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery/}
 fi
 # Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,14 +5,14 @@ DEFAULT_XENIA_COMMAND_PATH=/go/src/github.com/coralproject/xenia/cmd/xenia
 
 # Create the database collections if environment variable XENIA_CREATE_DATABASE is present.
 # XENIA_DATABASE_JSON - the location of the scrdb json.
-if [ -z ${XENIA_CREATE_DATABASE:-} ]; then
+if [ ! -z ${XENIA_CREATE_DATABASE:-} ]; then
     /go/bin/xenia db create -f ${XENIA_DATABASE_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
 fi  
 
 # Update queries if the environment variable XENIA_UPDATE_QUERY is present.
 # XENIA_QUERY_JSON - the location of the scrquery directory.
-if [ -z ${XENIA_UPDATE_QUERY:-}]; then
+if [ ! -z ${XENIA_UPDATE_QUERY:-}]; then
     /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery/}
-
+fi
 # Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.
 /go/bin/xeniad "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ETeu -o pipefail
+
+DEFAULT_XENIA_COMMAND_PATH=/go/src/github.com/coralproject/xenia/cmd/xenia
+
+# Create the database collections if environment variable XENIA_CREATE_DATABASE is present.
+# XENIA_DATABASE_JSON - the location of the scrdb json.
+if [ -z "${XENIA_CREATE_DATABASE:-}" ]; then
+    /go/bin/xenia db create -f ${XENIA_DATABASE_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
+fi  
+
+# Update queries if the environment variable XENIA_UPDATE_QUERY is present.
+# XENIA_QUERY_JSON - the location of the scrquery directory.
+if [ -z "${XENIA_UPDATE_QUERY:-}"]; then
+    /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery/}
+
+# Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.
+/go/bin/xeniad "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,17 +2,19 @@
 set -ETeu -o pipefail
 
 DEFAULT_XENIA_COMMAND_PATH=/go/src/github.com/coralproject/xenia/cmd/xenia
+PATH=/go/bin:${PATH}
 
 # Create the database collections if environment variable XENIA_CREATE_DATABASE is present.
 # XENIA_DATABASE_JSON - the location of the scrdb json.
 if [ ! -z ${XENIA_CREATE_DATABASE:-} ]; then
-    /go/bin/xenia db create -f ${XENIA_DATABASE_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
+    xenia db create -f ${XENIA_DATABASE_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
 fi  
 
 # Update queries if the environment variable XENIA_UPDATE_QUERY is present.
 # XENIA_QUERY_JSON - the location of the scrquery directory.
 if [ ! -z ${XENIA_UPDATE_QUERY:-} ]; then
-    /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery}
+    xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery}
 fi
+
 # Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.
-/go/bin/xeniad "$@"
+xeniad "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 # Update queries if the environment variable XENIA_UPDATE_QUERY is present.
 # XENIA_QUERY_JSON - the location of the scrquery directory.
 if [ ! -z ${XENIA_UPDATE_QUERY:-} ]; then
-    /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery/}
+    /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery}
 fi
 # Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.
 /go/bin/xeniad "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,13 @@ DEFAULT_XENIA_COMMAND_PATH=/go/src/github.com/coralproject/xenia/cmd/xenia
 
 # Create the database collections if environment variable XENIA_CREATE_DATABASE is present.
 # XENIA_DATABASE_JSON - the location of the scrdb json.
-if [ -z "${XENIA_CREATE_DATABASE:-}" ]; then
+if [ -z ${XENIA_CREATE_DATABASE:-} ]; then
     /go/bin/xenia db create -f ${XENIA_DATABASE_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrdb/database.json}
 fi  
 
 # Update queries if the environment variable XENIA_UPDATE_QUERY is present.
 # XENIA_QUERY_JSON - the location of the scrquery directory.
-if [ -z "${XENIA_UPDATE_QUERY:-}"]; then
+if [ -z ${XENIA_UPDATE_QUERY:-}]; then
     /go/bin/xenia query upsert -p ${XENIA_QUERY_JSON:-${DEFAULT_XENIA_COMMAND_PATH}/scrquery/}
 
 # Run the Xenia daemon last and always to maintain backwards compatibility with previous Dockerfile version.


### PR DESCRIPTION
## What does this PR do?
This PR includes some DevOps related changes to the xenia docker configuration. If accepted, I have some changes to coralproject/docs for its docker-compose.yml file.

1. Allows users to path an absolute or relative path to the xenia CLI tool (upsert.go) as the previous version would always append the current working directory even if it was an absolute path.
2. Build all project binaries as part of the Dockerfile so that they're available for use via the `docker run` command. In this case, we add the `xenia` binary to be built.
3. Allow users to initialize their database and update their queries (running xenia CLI) on container startup using the presence of an environment variable. This part adds an `entrypoint.sh` script that replaces /go/bin/xeniad to allow for additional startup behavior.

## How do I test this PR?
1. Within the Dockerfile's directory, create an env.list file with the following required environment variables:
```
XENIA_MONGO_HOST="127.0.0.1:27017"
XENIA_AUTH="OFF"
XENIA_MONGO_AUTHDB="coral"
XENIA_MONGO_DB="coral"
XENIA_MONGO_USER=
XENIA_MONGO_PASS=
XENIA_LOGGING_LEVEL=1
XENIA_HOST=":4000"
```

2. `docker build ./`
3. `docker run ${ID}`

This is to see that the default behavior has not changed.

1. Modify env.list to include XENIA_CREATE_DATABASE and/or XENIA_UPDATE_QUERY so that they are non-empty.
2. `docker build ./`
3. `docker run ${ID}`

This is to see that the entrypoint script will attempt to initialize the database schema and/or update queries.


1. Modify env.list to now include different directories for scrdb and scrquery by setting XENIA_DATABASE_SCHEMA_PATH and/or XENIA_QUERY_UPSERT_PATH} to any directory name (existing or not).
2. `docker build ./`
3. `docker run ${ID}`

Whether or not the files exist, you should at least see an error containing the directory/file it tried to read.

EDIT: Forgot the test case for the binary.
1. `cd cmd/xenia`
2. `go build .`
3. Export these variables or source them from a file.
```
XENIA_MONGO_HOST="127.0.0.1:27017"
XENIA_AUTH="OFF"
XENIA_MONGO_AUTHDB="coral"
XENIA_MONGO_DB="coral"
XENIA_MONGO_USER=
XENIA_MONGO_PASS=
XENIA_LOGGING_LEVEL=1
XENIA_HOST=":4000"
``` 
4. Run `./xenia db create -f ./scrdb/database.json` and `./xenia db create -f <abs_path>/scrdb/database.json`
5. Run `./xenia query upsert -p ./scrquery` and  `./xenia query upsert -p <abs_path>/scrquery`
6. Both the absolute and relative paths should be accepted for either.
